### PR TITLE
Updating the | symbol placed between <li> tags to match core Bugzilla.

### DIFF
--- a/template/en/default/hook/global/common-links-link-row.html.tmpl
+++ b/template/en/default/hook/global/common-links-link-row.html.tmpl
@@ -18,6 +18,9 @@
   <ul id="bb_common_links" class="links bb_common_links">
   [%- FOREACH item IN bb_common_links -%]
     <li>
+      [% IF NOT loop.first %]
+          <span class="separator">| </span>
+      [% END %]
       <a
       [% IF item.id %]
           id="[% item.id %]"
@@ -27,9 +30,6 @@
       [% END %]
       >[% item.text %]</a>
     </li>
-      [% IF NOT loop.last %]
-          |
-      [% END %]
   [%- END -%]
   </ul>
 [% END %]


### PR DESCRIPTION
The old method was invalid markup, as the | symbol was between &lt;li&gt; elements.  This came about because previously these were just inline &lt;a&gt; tags, where separators after all but the last item made sense.  However, this wasn't updated when they were made into &lt;li&gt; tags.

This commit restyles them to match the way that Bugzilla outputs the separator in its built-in menu lists, so they can be styled in the same way.
